### PR TITLE
8.0 hr employee

### DIFF
--- a/hr_employee_id/README.rst
+++ b/hr_employee_id/README.rst
@@ -1,9 +1,10 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-    :alt: License: AGPL-3
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
 
-===============================
+============================
 Employee Identification Numbers
-===============================
+============================
 
 Company wide unique employee ID. Supports
 * Random ID Generation
@@ -37,6 +38,9 @@ Usage
 When you will create a new employee, the field reference will be
 assigned automatically with the next number of the predefined sequence.
 
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/116/8.0
 
 Bug Tracker
 ===========

--- a/hr_employee_id/__init__.py
+++ b/hr_employee_id/__init__.py
@@ -1,20 +1,5 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2011,2013 Michael Telahun Makonnen <mmakonnen@gmail.com>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2011, 2013 Michael Telahun Makonnen <mmakonnen@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import models

--- a/hr_employee_id/__openerp__.py
+++ b/hr_employee_id/__openerp__.py
@@ -7,7 +7,7 @@
     'license': 'AGPL-3',
     'category': 'Generic Modules/Human Resources',
     'author': 'Michael Telahun Makonnen, '
-              'Odoo Community Association (OCA)',
+                    'Odoo Community Association (OCA)',
     'website': 'http://miketelahun.wordpress.com',
     'license': 'AGPL-3',
     'depends': [

--- a/hr_employee_id/__openerp__.py
+++ b/hr_employee_id/__openerp__.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2011,2013 Michael Telahun Makonnen <mmakonnen@gmail.com>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2011, 2013 Michael Telahun Makonnen <mmakonnen@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Employee ID',
     'version': '8.0.1.0.0',

--- a/hr_employee_id/__openerp__.py
+++ b/hr_employee_id/__openerp__.py
@@ -7,9 +7,8 @@
     'license': 'AGPL-3',
     'category': 'Generic Modules/Human Resources',
     'author': 'Michael Telahun Makonnen, '
-                    'Odoo Community Association (OCA)',
+              'Odoo Community Association (OCA)',
     'website': 'http://miketelahun.wordpress.com',
-    'license': 'AGPL-3',
     'depends': [
         'hr',
     ],

--- a/hr_employee_id/models/__init__.py
+++ b/hr_employee_id/models/__init__.py
@@ -1,22 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2011,2013 Michael Telahun Makonnen <mmakonnen@gmail.com>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2011, 2013 Michael Telahun Makonnen <mmakonnen@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import hr_employee
 from . import res_company
 from . import res_config

--- a/hr_employee_id/models/hr_employee.py
+++ b/hr_employee_id/models/hr_employee.py
@@ -14,7 +14,7 @@ class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
     identification_id = fields.Char(
-        'Identification No',
+        string='Identification No',
         copy=False
     )
 

--- a/hr_employee_id/models/hr_employee.py
+++ b/hr_employee_id/models/hr_employee.py
@@ -1,22 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2011,2013 Michael Telahun Makonnen <mmakonnen@gmail.com>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2011, 2013 Michael Telahun Makonnen <mmakonnen@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 import random
 import string
 from openerp import models, fields, api, _

--- a/hr_employee_id/models/res_company.py
+++ b/hr_employee_id/models/res_company.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-###############################################################################
-#
-#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-###############################################################################
+# © 2015 Salton Massally <smassally@idtlabs.sl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields
 

--- a/hr_employee_id/models/res_company.py
+++ b/hr_employee_id/models/res_company.py
@@ -9,7 +9,7 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     employee_id_gen_method = fields.Selection(
-        [
+        selection=[
             ('random', 'Random'),
             ('sequence', 'Sequence'),
         ],
@@ -17,10 +17,12 @@ class ResCompany(models.Model):
         default='random'
     )
     employee_id_random_digits = fields.Integer(
-        '# of Digits', default=5,
+        string='# of Digits',
+        default=5,
         help="Number of digits making up the ID"
     )
     employee_id_sequence = fields.Many2one(
-        'ir.sequence', 'Sequence',
+        comodel_name='ir.sequence',
+        string='Sequence',
         help="Pattern to be used for used for ID Generation",
     )

--- a/hr_employee_id/models/res_config.py
+++ b/hr_employee_id/models/res_config.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-###############################################################################
-#
-#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-###############################################################################
+# © 2015 Salton Massally <smassally@idtlabs.sl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields, api
 

--- a/hr_employee_id/models/res_config.py
+++ b/hr_employee_id/models/res_config.py
@@ -13,7 +13,7 @@ class HumanResourcesConfiguration(models.TransientModel):
         return sequence and sequence.id or False
 
     employee_id_gen_method = fields.Selection(
-        [
+        selection=[
             ('random', 'Random'),
             ('sequence', 'Sequence'),
         ],
@@ -21,11 +21,13 @@ class HumanResourcesConfiguration(models.TransientModel):
         default='random'
     )
     employee_id_random_digits = fields.Integer(
-        '# of Digits', default=5,
+        string='# of Digits',
+        default=5,
         help="Number of digits making up the ID"
     )
     employee_id_sequence = fields.Many2one(
-        'ir.sequence', 'Sequence',
+        comodel_name='ir.sequence',
+        string='Sequence',
         help="Pattern to be used for used for ID Generation",
         default=_default_id_sequence
     )

--- a/hr_employee_id/tests/__init__.py
+++ b/hr_employee_id/tests/__init__.py
@@ -1,21 +1,5 @@
 # -*- coding: utf-8 -*-
-###############################################################################
-#
-#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-###############################################################################
+# © 2015 Salton Massally <smassally@idtlabs.sl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_employee_id

--- a/hr_employee_id/tests/test_employee_id.py
+++ b/hr_employee_id/tests/test_employee_id.py
@@ -1,22 +1,7 @@
 # -*- coding: utf-8 -*-
-###############################################################################
-#
-#    Copyright (C) 2015 Salton Massally (<smassally@idtlabs.sl>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-###############################################################################
+# © 2015 Salton Massally <smassally@idtlabs.sl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp.tests import common
 
 


### PR DESCRIPTION
- README.rst adjust to OCA guidelines
- Use OCA simple header for all .py
- Use named parameter on all field declaration

Travis and runbot probably is still failed because test on other module. It already fix on https://github.com/OCA/hr/pull/194, but not merged yet
